### PR TITLE
refactor: Dockerfile and CI

### DIFF
--- a/.github/workflows/publishDockerImage.yml
+++ b/.github/workflows/publishDockerImage.yml
@@ -13,7 +13,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -25,7 +28,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: im2nguyen/rover
-      
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
@@ -33,3 +36,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-# Prep base stage
 ARG TF_VERSION=light
+
+# for UPX binary
+FROM pratikimprowise/upx as upx
+
+# for terraform binary
+FROM hashicorp/terraform:$TF_VERSION AS terraform
 
 # Build ui
 FROM node:16-alpine as ui
 WORKDIR /src
-# Copy specific package files
-COPY ./ui/package-lock.json ./
-COPY ./ui/package.json ./
+# Copy specific package files first
+COPY ./ui/package*.json ./
 # Set Progress, Config and install
 RUN npm set progress=false && npm config set depth 0 && npm install
 # Copy source
@@ -17,24 +21,30 @@ COPY ./ui/src ./src
 RUN npm run build
 
 # Build rover
-FROM golang:1.17 AS rover
+FROM golang:1.17-alpine AS rover
+# Copy upx
+COPY --from=upx / /
 WORKDIR /src
-# Copy full source
+# Install certs to copy it in build image
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+# Copy go.mod and go.sum
+COPY go.* .
+# Download go mods
+RUN go mod download
+# Copy source
 COPY . .
 # Copy ui/dist from ui stage as it needs to embedded
 COPY --from=ui ./src/dist ./ui/dist
-# Build rover
-RUN go get -d -v golang.org/x/net/html  
-RUN CGO_ENABLED=0 GOOS=linux go build -o rover .
-
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w"
+RUN upx -9 rover || true
 # Release stage
-FROM hashicorp/terraform:$TF_VERSION AS release
-# Copy terraform binary to the rover's default terraform path
-RUN cp /bin/terraform /usr/local/bin/terraform
-# Copy rover binary
-COPY --from=rover /src/rover /bin/rover
-RUN chmod +x /bin/rover
-
+FROM scratch as release
+WORKDIR /tmp
 WORKDIR /src
-
-ENTRYPOINT [ "/bin/rover" ]
+# Copy terraform binary to default terraform path
+COPY --from=terraform /bin/terraform  /usr/local/bin/terraform
+# Copy certs
+COPY --from=rover     /etc/ssl/certs/ /etc/ssl/certs/
+# Copy rover binary
+COPY --from=rover     /src/rover      /usr/local/bin/rover
+ENTRYPOINT ["/usr/local/bin/rover"]


### PR DESCRIPTION
### Overview

- Release image from scratch
- Copy terraform from its image
- Use `-s -w` ldflags with trimpath to build rover binary with least size of (14M), more [here](https://pkg.go.dev/cmd/link)
- Use UPX to compress the binray without any performance penalty AFAIK, more [here](https://en.wikipedia.org/wiki/UPX)
- Change rover path as terraform's
- Create `/tmp` dir as its necessaryfor rover
- Copy certs for terraform
- Use buildx for building docker image with parallel multi stage and better caching with `gha` support 

### Binary size

go build = `17MB`
`17188 -rwxr-xr-x  1 pratik pratik 17596884 Dec 18 19:28 rover`

go build -trimpath -ldflags "-s -w" = `14M`
`13780 -rwxr-xr-x  1 pratik pratik 14110720 Dec 18 19:29 rover`

go build -trimpath -ldflags "-s -w" + UPX = `4.3M`
`4348 -rwxr-xr-x  1 pratik pratik 4452056 Dec 18 19:30 rover`

```log
$> upx -9 rover   

                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2020
UPX 3.96        Markus Oberhumer, Laszlo Molnar & John Reiser   Jan 23rd 2020

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
  14110648 ->   4452056   31.55%   linux/amd64   rover                         

Packed 1 file.
```

### Container Image size

- Current image size `im2nguyen/rover:v0.2.2` latest size `85MB`
- New image size `23MB`

### Security

Rover container image `im2nguyen/rover:v0.2.2` which is latest got these many vulnerability 

```log
2021-12-18T19:27:15.068+0530	[34mINFO[0m	Detected OS: alpine
2021-12-18T19:27:15.068+0530	[34mINFO[0m	Detecting Alpine vulnerabilities...
2021-12-18T19:27:15.072+0530	[34mINFO[0m	Number of language-specific files: 3
2021-12-18T19:27:15.072+0530	[34mINFO[0m	Detecting gobinary vulnerabilities...

im2nguyen/rover (alpine 3.14.2)
===============================
Total: 29 (UNKNOWN: 0, LOW: 0, MEDIUM: 4, HIGH: 25, CRITICAL: 0)

+------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|        LIBRARY         | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| busybox                | CVE-2021-42378   | HIGH     | 1.33.1-r3         | 1.33.1-r6     | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42378 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42379   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42379 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42380   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42380 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42381   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42381 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42382   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42382 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42383   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42383 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42384   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42384 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42385   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42385 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42386   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42386 |
+                        +------------------+----------+                   +---------------+---------------------------------------+
|                        | CVE-2021-42374   | MEDIUM   |                   | 1.33.1-r4     | busybox: out-of-bounds read           |
|                        |                  |          |                   |               | in unlzma applet leads to             |
|                        |                  |          |                   |               | information leak and denial...        |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42374 |
+                        +------------------+          +                   +---------------+---------------------------------------+
|                        | CVE-2021-42375   |          |                   | 1.33.1-r5     | busybox: incorrect handling           |
|                        |                  |          |                   |               | of a special element in               |
|                        |                  |          |                   |               | ash applet leads to...                |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42375 |
+------------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| openssh                | CVE-2021-41617   | HIGH     | 8.6_p1-r2         | 8.6_p1-r3     | openssh: privilege escalation         |
|                        |                  |          |                   |               | when AuthorizedKeysCommand or         |
|                        |                  |          |                   |               | AuthorizedPrincipalsCommand           |
|                        |                  |          |                   |               | are configured                        |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-41617 |
+------------------------+                  +          +                   +               +                                       +
| openssh-client-common  |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
+------------------------+                  +          +                   +               +                                       +
| openssh-client-default |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
+------------------------+                  +          +                   +               +                                       +
| openssh-keygen         |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
+------------------------+                  +          +                   +               +                                       +
| openssh-server         |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
+------------------------+                  +          +                   +               +                                       +
| openssh-server-common  |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
+------------------------+                  +          +                   +               +                                       +
| openssh-sftp-server    |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
|                        |                  |          |                   |               |                                       |
+------------------------+------------------+          +-------------------+---------------+---------------------------------------+
| ssl_client             | CVE-2021-42378   |          | 1.33.1-r3         | 1.33.1-r6     | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42378 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42379   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42379 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42380   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42380 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42381   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42381 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42382   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42382 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42383   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42383 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42384   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42384 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42385   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42385 |
+                        +------------------+          +                   +               +---------------------------------------+
|                        | CVE-2021-42386   |          |                   |               | busybox: use-after-free in            |
|                        |                  |          |                   |               | awk applet leads to denial            |
|                        |                  |          |                   |               | of service and possibly...            |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42386 |
+                        +------------------+----------+                   +---------------+---------------------------------------+
|                        | CVE-2021-42374   | MEDIUM   |                   | 1.33.1-r4     | busybox: out-of-bounds read           |
|                        |                  |          |                   |               | in unlzma applet leads to             |
|                        |                  |          |                   |               | information leak and denial...        |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42374 |
+                        +------------------+          +                   +---------------+---------------------------------------+
|                        | CVE-2021-42375   |          |                   | 1.33.1-r5     | busybox: incorrect handling           |
|                        |                  |          |                   |               | of a special element in               |
|                        |                  |          |                   |               | ash applet leads to...                |
|                        |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-42375 |
+------------------------+------------------+----------+-------------------+---------------+---------------------------------------+

bin/rover (gobinary)
====================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


bin/terraform (gobinary)
========================
Total: 10 (UNKNOWN: 1, LOW: 0, MEDIUM: 4, HIGH: 5, CRITICAL: 0)

+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
|           LIBRARY            | VULNERABILITY ID | SEVERITY |          INSTALLED VERSION           |            FIXED VERSION             |                 TITLE                 |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/gogo/protobuf     | CVE-2021-3121    | HIGH     | v1.2.2-0.20190723190241-65acae22fc9d | v1.3.2                               | gogo/protobuf:                        |
|                              |                  |          |                                      |                                      | plugin/unmarshal/unmarshal.go         |
|                              |                  |          |                                      |                                      | lacks certain index validation        |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-3121  |
+------------------------------+------------------+          +--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/hashicorp/consul  | CVE-2020-7219    |          | v0.0.0-20171026175957-610f3c86a089   | v1.6.3                               | consul: HTTP/RPC Services             |
|                              |                  |          |                                      |                                      | Allow Unbounded Resource Usage        |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-7219  |
+                              +------------------+          +                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2021-3121    |          |                                      | v1.8.15, v1.9.9, v1.10.2             | gogo/protobuf:                        |
|                              |                  |          |                                      |                                      | plugin/unmarshal/unmarshal.go         |
|                              |                  |          |                                      |                                      | lacks certain index validation        |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-3121  |
+                              +------------------+          +                                      +                                      +---------------------------------------+
|                              | CVE-2021-37219   |          |                                      |                                      | consul: RPC layer allows              |
|                              |                  |          |                                      |                                      | non-server agents to access           |
|                              |                  |          |                                      |                                      | server-only functionality             |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-37219 |
+                              +------------------+----------+                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2020-25864   | MEDIUM   |                                      | v1.7.14, v1.8.10, v1.9.5             | consul: specially crafted KV entry    |
|                              |                  |          |                                      |                                      | could be used to perform a XSS...     |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-25864 |
+                              +------------------+          +                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2021-38698   |          |                                      | v1.8.15, v1.9.9, v1.10.2             | Incorrect Authorization               |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-38698 |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/hashicorp/go-slug | CVE-2020-29529   | HIGH     | v0.4.1                               | v0.5.0                               | go-slug: partial protection           |
|                              |                  |          |                                      |                                      | against zip slip attacks              |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-29529 |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/satori/go.uuid    | GO-2020-0018     | UNKNOWN  | v1.2.0                               | v1.2.1-0.20181016170032-d91630c85102 |                                       |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| k8s.io/client-go             | CVE-2019-11250   | MEDIUM   | v0.0.0-20190620085101-78d2af792bab   | v0.17.0                              | kubernetes: Bearer tokens             |
|                              |                  |          |                                      |                                      | written to logs at high               |
|                              |                  |          |                                      |                                      | verbosity levels (>= 7)...            |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2019-11250 |
+                              +------------------+          +                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2020-8565    |          |                                      | v0.20.0-alpha.2                      | kubernetes: Incomplete fix            |
|                              |                  |          |                                      |                                      | for CVE-2019-11250 allows for         |
|                              |                  |          |                                      |                                      | token leak in logs when...            |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-8565  |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+

usr/local/bin/terraform (gobinary)
==================================
Total: 10 (UNKNOWN: 1, LOW: 0, MEDIUM: 4, HIGH: 5, CRITICAL: 0)

+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
|           LIBRARY            | VULNERABILITY ID | SEVERITY |          INSTALLED VERSION           |            FIXED VERSION             |                 TITLE                 |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/gogo/protobuf     | CVE-2021-3121    | HIGH     | v1.2.2-0.20190723190241-65acae22fc9d | v1.3.2                               | gogo/protobuf:                        |
|                              |                  |          |                                      |                                      | plugin/unmarshal/unmarshal.go         |
|                              |                  |          |                                      |                                      | lacks certain index validation        |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-3121  |
+------------------------------+------------------+          +--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/hashicorp/consul  | CVE-2020-7219    |          | v0.0.0-20171026175957-610f3c86a089   | v1.6.3                               | consul: HTTP/RPC Services             |
|                              |                  |          |                                      |                                      | Allow Unbounded Resource Usage        |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-7219  |
+                              +------------------+          +                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2021-3121    |          |                                      | v1.8.15, v1.9.9, v1.10.2             | gogo/protobuf:                        |
|                              |                  |          |                                      |                                      | plugin/unmarshal/unmarshal.go         |
|                              |                  |          |                                      |                                      | lacks certain index validation        |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-3121  |
+                              +------------------+          +                                      +                                      +---------------------------------------+
|                              | CVE-2021-37219   |          |                                      |                                      | consul: RPC layer allows              |
|                              |                  |          |                                      |                                      | non-server agents to access           |
|                              |                  |          |                                      |                                      | server-only functionality             |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-37219 |
+                              +------------------+----------+                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2020-25864   | MEDIUM   |                                      | v1.7.14, v1.8.10, v1.9.5             | consul: specially crafted KV entry    |
|                              |                  |          |                                      |                                      | could be used to perform a XSS...     |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-25864 |
+                              +------------------+          +                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2021-38698   |          |                                      | v1.8.15, v1.9.9, v1.10.2             | Incorrect Authorization               |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2021-38698 |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/hashicorp/go-slug | CVE-2020-29529   | HIGH     | v0.4.1                               | v0.5.0                               | go-slug: partial protection           |
|                              |                  |          |                                      |                                      | against zip slip attacks              |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-29529 |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| github.com/satori/go.uuid    | GO-2020-0018     | UNKNOWN  | v1.2.0                               | v1.2.1-0.20181016170032-d91630c85102 |                                       |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
| k8s.io/client-go             | CVE-2019-11250   | MEDIUM   | v0.0.0-20190620085101-78d2af792bab   | v0.17.0                              | kubernetes: Bearer tokens             |
|                              |                  |          |                                      |                                      | written to logs at high               |
|                              |                  |          |                                      |                                      | verbosity levels (>= 7)...            |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2019-11250 |
+                              +------------------+          +                                      +--------------------------------------+---------------------------------------+
|                              | CVE-2020-8565    |          |                                      | v0.20.0-alpha.2                      | kubernetes: Incomplete fix            |
|                              |                  |          |                                      |                                      | for CVE-2019-11250 allows for         |
|                              |                  |          |                                      |                                      | token leak in logs when...            |
|                              |                  |          |                                      |                                      | -->avd.aquasec.com/nvd/cve-2020-8565  |
+------------------------------+------------------+----------+--------------------------------------+--------------------------------------+---------------------------------------+
```

New Scratch release image got single fixable uuid vulnerability

```logs
$> trivy image pratikimprowise/rover:test               

2021-12-18T19:33:01.742+0530	INFO	Number of language-specific files: 1
2021-12-18T19:33:01.742+0530	INFO	Detecting gobinary vulnerabilities...

usr/local/bin/terraform (gobinary)
==================================
Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

+---------------------------+------------------+----------+-------------------+--------------------------------------+-------+
|          LIBRARY          | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |            FIXED VERSION             | TITLE |
+---------------------------+------------------+----------+-------------------+--------------------------------------+-------+
| github.com/satori/go.uuid | GO-2020-0018     | UNKNOWN  | v1.2.0            | v1.2.1-0.20181016170032-d91630c85102 |       |
+---------------------------+------------------+----------+-------------------+--------------------------------------+-------+
```

---

May the source be with you