### PR TITLE
Fix UI package lock file

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ui",
       "version": "0.1.0",
       "dependencies": {
         "axios": "^0.21.1",
@@ -19463,6 +19464,12 @@
         "lodash.memoize": "^4.1.2",
         "lodash.uniq": "^4.5.0"
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001208",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
+      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+      "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",


### PR DESCRIPTION
Seems the package-lock.json did not include all the dependencies. I just
re-ran with npm 8.1.2 under node 16.13.1

This does not seem to be an issue under this version combination, but when I ran with npm 6.14.15 under node 14.18.1 it was not possible to run `npm ci` without it complaining about `npm ERR! caniuse-lite not accessible from browserslist`.