### PR TITLE
Fix panic when no resources in configuration

### DIFF
--- a/example/simple-test/main.tf
+++ b/example/simple-test/main.tf
@@ -1,0 +1,3 @@
+output "hello_world" {
+  value = "Hello, World!"
+}

--- a/graph.go
+++ b/graph.go
@@ -244,10 +244,6 @@ func (r *rover) addEdges(base string, parent string, edgeMap map[string]Edge, re
 
 		configId := matchBrackets.ReplaceAllString(id, "")
 
-		if _, ok := r.RSO.States[id]; ok {
-			configId = r.RSO.States[id].ConfigId
-		}
-
 		var expressions map[string]*tfjson.Expression
 
 		if r.RSO.Configs[configId] != nil {


### PR DESCRIPTION
Hey @im2nguyen , this resolves #87 . The issue was just that since there were no actual resources in the plan, there is no root module in the RSO state map. So we just create a placeholder root module in the state map if there is not one.