### PR TITLE
fix(): fix data array runtime error

### DIFF
--- a/rso.go
+++ b/rso.go
@@ -191,7 +191,11 @@ func (r *rover) PopulateModuleState(rso *ResourcesOverview, module *tfjson.State
 				if _, ok := rs[parent]; !ok {
 					rs[parent] = &StateOverview{}
 					rs[parent].Children = make(map[string]*StateOverview)
-					rs[parent].Type = ResourceTypeResource
+					if rst.Mode == "data" {
+						rs[parent].Type = ResourceTypeData
+					} else {
+						rs[parent].Type = ResourceTypeResource
+					}
 
 				}
 


### PR DESCRIPTION
TL;DR: Allow for index type resources to be `ResourceTypeData` 

This is an update to allow for Data type resources that are index based that use `count` or `for_each`. This is currently causing a runtime panic as described in #90 . This update will resolve the runtime panic and allow for the graph to be successfully generated but there may be some visual issues as a result. 