### PR TITLE
feat(docker): use latest TF version and update rovers default TF path

### DIFF
--- a/.github/workflows/publishDockerImage.yml
+++ b/.github/workflows/publishDockerImage.yml
@@ -33,5 +33,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args:
-            TF_VERSION=1.1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Prep base stage
-ARG TF_VERSION=light
+ARG TF_VERSION=1.5.5
 
 # Build ui
 FROM node:20-alpine as ui
@@ -30,8 +30,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o rover .
 
 # Release stage
 FROM hashicorp/terraform:$TF_VERSION AS release
-# Copy terraform binary to the rover's default terraform path
-RUN cp /bin/terraform /usr/local/bin/terraform
+
 # Copy rover binary
 COPY --from=rover /src/rover /bin/rover
 RUN chmod +x /bin/rover

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	var tfPath, workingDir, name, zipFileName, ipPort, planPath, planJSONPath, workspaceName, tfcOrgName, tfcWorkspaceName string
 	var standalone, genImage, showSensitive, getVersion, tfcNewRun bool
 	var tfVarsFiles, tfVars, tfBackendConfigs arrayFlags
-	flag.StringVar(&tfPath, "tfPath", "/usr/local/bin/terraform", "Path to Terraform binary")
+	flag.StringVar(&tfPath, "tfPath", "/bin/terraform", "Path to Terraform binary")
 	flag.StringVar(&workingDir, "workingDir", ".", "Path to Terraform configuration")
 	flag.StringVar(&name, "name", "rover", "Configuration name")
 	flag.StringVar(&zipFileName, "zipFileName", "rover", "Standalone zip file name")


### PR DESCRIPTION
Hi,

I havent really followed https://github.com/im2nguyen/rover/pull/69, but this PR is perhaps a smaller fix when using rovers docker image and thus easier to review / merge.

Firstly, Terraform was twice installed (`/usr/local/bin/terraform` & `/bin/terraform`) with outdated versions. This PR fixes this, uses the latest stable TF version (`v1.5.5`) and changes rovers default TF path to match the one in the container (`/bin/terraform`).

What do you think?
